### PR TITLE
Feedback on Trust and Ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,20 +183,27 @@ Any resource can specify any link metadata predicate for itself and for any subr
 
 can specify:
 
-`&lt;/foo/bar&lt; lm:redirectPermanent &lt;/bar/foo/&gt;`
+```turtle
+</foo/bar> lm:redirectPermanent </bar/foo/>
+```
 
 or even:
 
-`&lt;/foo&lt; lm:redirectPermanent &lt;/bar/&gt;`
+```turtle
+</foo> lm:redirectPermanent </bar/>
+```
 
 it cannot specify:
 
-`&lt;/&lt; lm:redirectPermanent &lt;/bar/&gt;`
+```turtle
+</> lm:redirectPermanent </bar/>
+```
 
 or:
 
-`&lt;https://solidcommunity.net/foo&lt; lm:redirectPermanent &lt;/bar/&gt;`
-
+```turtle
+<https://solidcommunity.net/foo> lm:redirectPermanent </bar/>
+```
 
 ### User supplied explicit trust
 

--- a/README.md
+++ b/README.md
@@ -179,9 +179,7 @@ Any resource can specify any link metadata predicate for itself and for any subr
 
 ### Examples
 
-`https://pod.example.org/foo/` 
-
-can specify:
+A resource at `https://pod.example.org/foo/` can specify:
 
 ```turtle
 </foo/bar> lm:redirectPermanent </bar/foo/>
@@ -209,11 +207,11 @@ or:
 
 A Solid user can specify that a specific resource is trusted. In that case this resource may specify link metadata predicates for any other resource, whether these are subresources or not.
 
-How the user specifies this is out of scope for this specification.
+How the user specifies such trust is out of scope for this specification.
 
 ### Server implementation details
 
-If a server implements the link metadata instructions through the `.meta` file specification, then the server must follow the URL based trust system. It must ignore any link metadata predicates that do not describe a subresource. 
+If a server implements Auxiliary Resources of type "Description Resource" (colloquially known as `.meta` files), then the server must follow the URL based trust system. It must ignore any link metadata predicates that do not describe a subresource. 
 
 It must also ignore link metadata predicates for the resource itself. For example, in `https://pod.example.org/` there is a resource named `foo`. If a user adds a `foo.meta` and in it adds a redirect predicate for the resource `https://pod.example.org/foo`, the server must ignore this.
 
@@ -227,11 +225,17 @@ It also makes it unnecessarily complex to create a user interface that allows yo
 
 Whenever a resource has a link metadata predicate for a specific entity, any other predicates for that same entity should be ignored.
 
-For example, say you delete a subject (entity) from a resource, and the application that you use, applies the lm:deleted predicate to it. This means that the subject no longer exists and any other predicates on it should also be ignored. Now if you 'undelete' the subject, all the application has to do is remove the lm:deleted predicate and all the information is back.
+For example, say you delete a subject (entity) from a resource, and the application that you use, applies the `lm:deleted` predicate to it. This means that the subject no longer exists and any other predicates on it should also be ignored. Now if you 'undelete' the subject, all the application has to do is remove the `lm:deleted` predicate and all the information is back.
 
-This should also work for redirect information. If you set a redirect (temporary or permanent) predicate on a subject, applications should only allow you to alter or remove those predicates. Any other predicates here are no longer valid and should no longer be used.
+This should also work for redirect information. If you set a redirect (temporary or permanent) predicate on a subject, applications should only allow you to alter or remove those predicates. Any other predicates there are no longer valid and should no longer be used.
 
-The reasoning here is that the redirect or deleted predicates explicitly invalidate the current subject URL. If this wasn't the case the exact information about the subject becomes ambiguous. If URL &lt;A> specifies &lt;A> `foaf:knows` &lt;B>, and &lt;A> `lm:redirectTemporary` &lt;C>. And URL &lt;C> specifies &lt;C> `foaf:knows` &lt;D>. Does this mean that &lt;A> knows &lt;B>,&lt;C>? Then you could no longer remove the `foaf:knows` &lt;B> information, there is no 'undo' option. 
+The reasoning here is that the redirect or deleted predicates explicitly invalidate the current subject URL. If this wasn't the case the exact information about the subject becomes ambiguous. Consider the following:
+
+- If URL &lt;A> specifies &lt;A> `foaf:knows` &lt;B>, and 
+- &lt;A> `lm:redirectTemporary` &lt;C>. 
+- And URL &lt;C> specifies &lt;C> `foaf:knows` &lt;D>. 
+
+Does this mean that &lt;A> knows &lt;B>,&lt;C>? Then you could no longer remove the `foaf:knows` &lt;B> information, there is no 'undo' option. 
 
 So only by ignoring all other predicates linked to &lt;A> can we completely redefine the knowledge in &lt;C>.
 


### PR DESCRIPTION
Some feedback regarding the new "Trust and Ambiguity" section.

Besides some formatting fixes (code blocks, etc.) and rewording, I propose the following replacing the term "`.meta` file" with the term "Auxiliary Resources". 